### PR TITLE
feat: add tts support

### DIFF
--- a/source/content-script/modifications/DOM/textContainer.ts
+++ b/source/content-script/modifications/DOM/textContainer.ts
@@ -3,7 +3,7 @@ import { fontSizeThemeVariable } from "../../../common/theme";
 import { asideWordBlocklist, blockedSpecificSelectors } from "../contentBlock";
 import { PageModifier, trackModifierExecution } from "../_interface";
 
-const globalTextElementSelector = "p, font, pre";
+export const globalTextElementSelector = "p, font, pre";
 const globalHeadingSelector = "header, h1, h2, h3, h4, picture, figure";
 
 const headingTags = globalHeadingSelector.split(", ");

--- a/source/content-script/modifications/texttospeech/texttospeechModifier.ts
+++ b/source/content-script/modifications/texttospeech/texttospeechModifier.ts
@@ -1,0 +1,32 @@
+import { trackModifierExecution } from "../_interface";
+import { globalTextElementSelector, lindyTextContainerClass } from "../DOM/textContainer"
+
+@trackModifierExecution
+export default class TextToSpeechModifier {
+    private speech: SpeechSynthesisUtterance;
+    private textElementSelector = `.${lindyTextContainerClass}, .${lindyTextContainerClass} > :is(${globalTextElementSelector}, a, ol)`;
+
+    enableTextToSpeech() {
+			this.speech = new SpeechSynthesisUtterance();
+
+			const article = document.querySelector(this.textElementSelector) as HTMLElement | null;
+
+			this.speech.lang = navigator.language;
+			this.speech.voice = window.speechSynthesis.getVoices()[0];
+			this.speech.text = 'From ' + document.location.hostname + '. ' + article.innerText;
+
+			window.speechSynthesis.speak(this.speech);
+    }
+
+    disableTextToSpeech() {
+			window.speechSynthesis.cancel();
+    }
+
+    setEnableTextToSpeech(enableTextToSpeech: boolean) {
+        if (enableTextToSpeech) {
+            this.enableTextToSpeech();
+        } else {
+            this.disableTextToSpeech();
+        }
+    }
+}

--- a/source/overlay/insert.ts
+++ b/source/overlay/insert.ts
@@ -23,6 +23,7 @@ import {
 import { togglePageView } from "../content-script/enhance";
 import { reportEventContentScript } from "../content-script/messaging";
 import AnnotationsModifier from "../content-script/modifications/annotations/annotationsModifier";
+import TextToSpeechModifier from "../content-script/modifications/texttospeech/texttospeechModifier";
 import ThemeModifier from "../content-script/modifications/CSSOM/theme";
 import OverlayManager from "../content-script/modifications/overlay";
 
@@ -388,6 +389,60 @@ export function updateSocialCommentsCount(count: number) {
     }
 
     _renderSocialToggle(count);
+}
+
+// *** Text to speech toggle ***
+let textToSpeechEnabled = null;
+async function _setupTextToSpeechToggle(
+    textToSpeechModifer: TextToSpeechModifier
+) {
+    textToSpeechEnabled = false;
+
+    const container = _renderTextToSpeechToggle();
+
+    container.onclick = () => {
+        textToSpeechEnabled = !textToSpeechEnabled;
+
+        _renderTextToSpeechToggle();
+
+        textToSpeechModifer.setEnableTextToSpeech(annotationsEnabled);
+
+        reportEventContentScript("toggleTextToSpeech", {
+            newState: textToSpeechEnabled,
+        });
+    };
+}
+function _renderTextToSpeechToggle() {
+    const container = document.getElementById(
+        "lindy-text-to-speech-toggle-container"
+    );
+    container.innerHTML = _getTextToSpeechToggleIcon(textToSpeechEnabled);
+    container.setAttribute(
+        "data-title",
+        _getTextToSpeechToggleTooltip(textToSpeechEnabled)
+    );
+
+    return container;
+}
+function _getTextToSpeechToggleTooltip(enabled: boolean): string {
+    if (enabled) {
+        return `Click to disable text to speech`;
+    } else {
+        return `Click to enable text to speech`;
+    }
+}
+function _getTextToSpeechToggleIcon(enabled: boolean): string {
+    if (enabled) {
+        return `
+        <svg class="lindy-ui-icon" id="lindy-text-to-speech-icon" viewBox="0 0 640 512" style="overflow: visible; margin-left: 1.5px; margin-right: -2.5px;">
+            <path fill="currentColor" d="M412.6 182c-10.28-8.334-25.41-6.867-33.75 3.402c-8.406 10.24-6.906 25.35 3.375 33.74C393.5 228.4 400 241.8 400 255.1c0 14.17-6.5 27.59-17.81 36.83c-10.28 8.396-11.78 23.5-3.375 33.74c4.719 5.806 11.62 8.802 18.56 8.802c5.344 0 10.75-1.779 15.19-5.399C435.1 311.5 448 284.6 448 255.1S435.1 200.4 412.6 182zM473.1 108.2c-10.22-8.334-25.34-6.898-33.78 3.34c-8.406 10.24-6.906 25.35 3.344 33.74C476.6 172.1 496 213.3 496 255.1s-19.44 82.1-53.31 110.7c-10.25 8.396-11.75 23.5-3.344 33.74c4.75 5.775 11.62 8.771 18.56 8.771c5.375 0 10.75-1.779 15.22-5.431C518.2 366.9 544 313 544 255.1S518.2 145 473.1 108.2zM534.4 33.4c-10.22-8.334-25.34-6.867-33.78 3.34c-8.406 10.24-6.906 25.35 3.344 33.74C559.9 116.3 592 183.9 592 255.1s-32.09 139.7-88.06 185.5c-10.25 8.396-11.75 23.5-3.344 33.74C505.3 481 512.2 484 519.2 484c5.375 0 10.75-1.779 15.22-5.431C601.5 423.6 640 342.5 640 255.1S601.5 88.34 534.4 33.4zM301.2 34.98c-11.5-5.181-25.01-3.076-34.43 5.29L131.8 160.1H48c-26.51 0-48 21.48-48 47.96v95.92c0 26.48 21.49 47.96 48 47.96h83.84l134.9 119.8C272.7 477 280.3 479.8 288 479.8c4.438 0 8.959-.9314 13.16-2.835C312.7 471.8 320 460.4 320 447.9V64.12C320 51.55 312.7 40.13 301.2 34.98z" />
+        </svg>`;
+    } else {
+        return `
+        <svg class="lindy-ui-icon" id="lindy-text-to-speech-icon" viewBox="0 0 640 512">
+            <path fill="currentColor" d="M320 64v383.1c0 12.59-7.337 24.01-18.84 29.16C296.1 479.1 292.4 480 288 480c-7.688 0-15.28-2.781-21.27-8.094l-134.9-119.9H48c-26.51 0-48-21.49-48-47.1V208c0-26.51 21.49-47.1 48-47.1h83.84l134.9-119.9c9.422-8.375 22.93-10.45 34.43-5.259C312.7 39.1 320 51.41 320 64z" />
+        </svg>`;
+    }
 }
 
 // *** Link icons: settings and bug report ***


### PR DESCRIPTION
This PR adds in TTS support via the [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API). TTS is handled via a button on the side of the article. Upon enabling TTS, the article's contents are grabbed and then piped into the Web Speech API, prefixed by "From" and then the hostname of the article; likewise, clicking the button again will cancel the current TTS operation.

Resolves: #11