### PR TITLE
Avoid blocking code in Medium articles

### DIFF
--- a/apps/unclutter/source/data/domainBlocklistSelectors.json
+++ b/apps/unclutter/source/data/domainBlocklistSelectors.json
@@ -840,7 +840,6 @@
         ".ns.nt.l",
         ".nr.l",
         ".nq.sl.l",
-        ".l.ln",
         ".rn.l",
         ".ws.hr.l.bl",
         ".o.ao",


### PR DESCRIPTION
I'm not sure what this rule was supposed to block, but it blocks code blocks, unfortunately. I noticed this on https://medium.com/windmill-engineering/bazel-is-the-worst-build-system-except-for-all-the-others-b369396a9e26.

By the way, Unclutter is fantastic! ⭐ ⭐ ⭐ ⭐ ⭐ 