### PR TITLE
Highlighting improvements

### DIFF
--- a/apps/unclutter/source/common/featureFlags.ts
+++ b/apps/unclutter/source/common/featureFlags.ts
@@ -56,7 +56,7 @@ export const defaultFeatureFlags = {
     [isDevelopmentFeatureFlag]: false,
     [enableSocialCountsFeatureFlag]: true,
 
-    [enableAnnotationsFeatureFlag]: true,
+    [enableAnnotationsFeatureFlag]: false,
     [enableSocialCommentsFeatureFlag]: true,
 
     [submittedFeedbackFlag]: false,

--- a/apps/unclutter/source/overlay/index.css
+++ b/apps/unclutter/source/overlay/index.css
@@ -186,7 +186,7 @@
     position: absolute !important;
     top: 8px !important;
     left: calc((100vw - var(--lindy-pagewidth)) / 2 + var(--lindy-pagewidth) - 4px) !important;
-    width: calc((100vw - var(--lindy-pagewidth)) / 2 - 8px - 4px) !important;
+    width: calc((100vw - var(--lindy-pagewidth)) / 2 - 8px - 34px) !important;
     height: calc(100% - 8px) !important;
     user-select: none !important;
     contain: strict !important;

--- a/apps/unclutter/source/overlay/index.css
+++ b/apps/unclutter/source/overlay/index.css
@@ -279,7 +279,7 @@
     }
     #lindy-annotations-bar {
         left: calc(var(--lindy-pagewidth) + 10px + 5px) !important;
-        width: calc(100vw - (var(--lindy-pagewidth) + 10px + 5px) - 15px) !important;
+        width: calc(100vw - (var(--lindy-pagewidth) + 10px + 5px) - 46px) !important;
     }
     .lindy-page-settings-pageadjacent {
         left: calc(var(--lindy-pagewidth) + 10px + 0px) !important;

--- a/apps/unclutter/source/overlay/ui/Controls/PrivateNotesControl.svelte
+++ b/apps/unclutter/source/overlay/ui/Controls/PrivateNotesControl.svelte
@@ -14,7 +14,7 @@
     export let smartHighlightsProxy: SmartHighlightsProxy;
     export let overlayModifier: OverlayManager;
 
-    let privateNotesEnabled: boolean = true;
+    let privateNotesEnabled: boolean = false;
     getFeatureFlag(enableAnnotationsFeatureFlag).then((defaultEnabled) => {
         privateNotesEnabled = defaultEnabled;
     });

--- a/apps/unclutter/source/sidebar/components/AnnotationDraft.tsx
+++ b/apps/unclutter/source/sidebar/components/AnnotationDraft.tsx
@@ -75,7 +75,7 @@ export default function AnnotationDraft({
     return (
         <div
             className={clsx(
-                `annotation annotation-draft relative rounded-l-sm rounded-r-md p-2 px-3 text-sm shadow`,
+                `annotation annotation-draft relative rounded-l-sm rounded-r-md p-2 px-3 text-sm shadow flex flex-wrap`,
                 annotation.focused && "focused",
                 className
             )}
@@ -84,11 +84,12 @@ export default function AnnotationDraft({
                 // @ts-ignore
                 "--dark-border-color": colorDark || color,
                 maxHeight: heightLimitPx,
+                minWidth: 110,
             }}
             // ref={ref}
         >
             <TextareaAutosize
-                className="w-full select-none resize-none overflow-hidden bg-transparent align-top outline-none placeholder:select-none placeholder:text-stone-400 dark:placeholder:text-stone-600"
+                className="select-none resize-none overflow-hidden bg-transparent align-top outline-none placeholder:select-none placeholder:text-stone-400 dark:placeholder:text-stone-600 grow"
                 placeholder={
                     userInfo?.aiEnabled
                         ? annotation.tags.map((t) => `#${t}`).join(" ")
@@ -116,9 +117,9 @@ export default function AnnotationDraft({
             {isFetching ? (
                 <div className="loader absolute right-3 top-[9px] h-4 w-4" />
             ) : (
-                <div className="animate-fadein absolute top-[1px] right-1 flex gap-0 text-stone-400 dark:text-stone-600">
+                <div className="animate-fadein flex gap-4 text-stone-400 dark:text-stone-600">
                     <svg
-                        className="annotation-button h-8 cursor-pointer p-2"
+                        className="annotation-button h-4 cursor-pointer"
                         viewBox="0 0 512 512"
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={() => copyTextToClipboard(`"${annotation.quote_text}"`)}
@@ -129,7 +130,7 @@ export default function AnnotationDraft({
                         />
                     </svg>
                     <svg
-                        className="annotation-button h-8 cursor-pointer p-2"
+                        className="annotation-button h-4 cursor-pointer"
                         viewBox="0 0 448 512"
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={() => deleteAnnotation(userInfo, annotation)}


### PR DESCRIPTION
This PR disables Highlighting by default as its behavior is usually unexpected and leads to frustrations
The "Saved highlight" box now always avoid the top right menu
![Screenshot 2024-06-24 at 4 08 24 PM](https://github.com/lindylearn/unclutter/assets/41023671/9435db2d-d16b-41b1-91f6-0a9336c91338)

The copy and delete buttons in the "Saved highlight" box now moves to a new line when the space is too small.
![Screenshot 2024-06-24 at 4 08 34 PM](https://github.com/lindylearn/unclutter/assets/41023671/bf77cd15-5287-4d22-b0cd-23359c912095)
